### PR TITLE
make some select functions in to templates to workaround modern compiler programmers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: d
 sudo: false
 
 d:
-  - dmd
-  - ldc
+  - dmd-2.094.2
+  - ldc-1.24.0
 
 script:
   - bash runalltests.sh ${DC}

--- a/pkgdescription/source/dud/pkgdescription/platformselection.d
+++ b/pkgdescription/source/dud/pkgdescription/platformselection.d
@@ -18,7 +18,7 @@ import dud.pkgdescription;
 import dud.semver.semver;
 import dud.semver.versionrange;
 
-PackageDescriptionNoPlatform select(const(PackageDescription) pkg,
+PackageDescriptionNoPlatform select()(const(PackageDescription) pkg,
 		const(Platform[]) platform)
 {
 	return selectImpl(pkg, platform);
@@ -128,7 +128,7 @@ struct DependencyNoPlatform {
 	Nullable!bool default_;
 }
 
-PackageDescriptionNoPlatform selectImpl(const(PackageDescription) pkg,
+PackageDescriptionNoPlatform selectImpl()(const(PackageDescription) pkg,
 		const(Platform[]) platform)
 {
 	import dud.pkgdescription.helper : isMem;
@@ -252,7 +252,7 @@ BuildRequirement[] select(const(BuildRequirements) brs,
 // Dependencies
 //
 
-DependencyNoPlatform select(const(Dependency) sp) {
+DependencyNoPlatform select()(const(Dependency) sp) {
 	DependencyNoPlatform ret;
 	ret.name = sp.name;
 	ret.path = ddup(sp.path);
@@ -262,7 +262,7 @@ DependencyNoPlatform select(const(Dependency) sp) {
 	return ret;
 }
 
-DependencyNoPlatform[string] select(const(Dependency[]) deps,
+DependencyNoPlatform[string] select()(const(Dependency[]) deps,
 		const(Platform[]) platform)
 {
 	Dependency[][string] sorted;
@@ -290,7 +290,7 @@ DependencyNoPlatform[string] select(const(Dependency[]) deps,
 // SubPackage(s)
 //
 
-SubPackageNoPlatform select(const(SubPackage) sp, const(Platform[]) platform) {
+SubPackageNoPlatform select()(const(SubPackage) sp, const(Platform[]) platform) {
 	SubPackageNoPlatform ret;
 	if(!sp.inlinePkg.isNull()) {
 		ret.inlinePkg.opAssign(select(sp.inlinePkg.get(), platform));
@@ -300,7 +300,7 @@ SubPackageNoPlatform select(const(SubPackage) sp, const(Platform[]) platform) {
 	return ret;
 }
 
-SubPackageNoPlatform[] select(const(SubPackage[]) sps, const(Platform[]) platform)
+SubPackageNoPlatform[] select()(const(SubPackage[]) sps, const(Platform[]) platform)
 {
 	return sps.map!(sp => select(sp, platform)).array;
 


### PR DESCRIPTION
this is disgusting and should be reverted, but shouldn't cause problems and I need it for now in SIL in order to use modern compilers

c.c. @uplinkcoder