### PR TITLE
Use correct key name for 'excludedSourceFiles'

### DIFF
--- a/testdata/dub.json
+++ b/testdata/dub.json
@@ -1,7 +1,7 @@
 {
 	"name": "testdata",
 	"targetType": "library",
-	"excludeSourceFiles" :
+	"excludedSourceFiles" :
 		[ "source/dud/testdata/main.d"
 		],
 


### PR DESCRIPTION
I was writing a stricter config parser for dub when it choked on dud.

![Screenshot from 2022-06-20 03-10-44](https://user-images.githubusercontent.com/2180215/174508983-bab29bcc-185e-4804-bfdb-1240c8cb8ef7.png)

